### PR TITLE
Update documentation and fix example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ projects:
   - key: DVP
     cost-unit:
       type: points
-        format:
-          singular: '%d point'
-          plural: '%d points'
+      format:
+        singular: '%d point'
+        plural: '%d points'
     cost-field: customfield_10006
     supported-work-types:
       - Bug

--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ You will need [Leiningen][] 2.0.0 or above installed.
 
 ### Running from the Command Line during development
 
+Make sure that you have proper configuration file in place. See [Configuration Path](#configuration-path)
+
 To start a web server for the application from the command line, run:
 
+    # Use default port 3004 and default config file 'codescene-jira.yml'
     lein run
+    
+    # Use custom port 3001 and default config file
     PORT=3001 lein run
+    
+    # Provide custom config file
     CODESCENE_JIRA_CONFIG=/etc/codescene-jira.yml lein run
+
     # Override database path (defaults to db/codescene-enterprise-pm-jira)
     CODESCENE_JIRA_DATABASE_PATH=/var/lib/codescene/codescene-enterprise-pm-jira lein run
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ the project. 1 means it has the work type, 0 means it doesn't.
 #### Example Request
 
 ```bash
-curl -i -X GET -H 'Accept: application/json' -u 'user:pass' https://jira-integration.codescene.io/api/1/projects/CSE
+curl -i -H 'Accept: application/json' -u 'user:pass' https://jira-integration.codescene.io/api/1/projects/CSE
 ```
 
 #### Example Response
@@ -197,7 +197,7 @@ a HTTP status of 200 for signaling that it is available and functional, and
 #### Example Request
 
 ```bash
-curl -i -X GET -H 'Accept: application/json' -u 'user:pass' https://jira-integration.codescene.io/api/1/status
+curl -i -H 'Accept: application/json' -u 'user:pass' https://jira-integration.codescene.io/api/1/status
 ```
 
 #### Example Response

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ Adding/replacing a project with some test data:
 > (def conn (codescene-enterprise-pm-jira.db/persistent-connection))
 > (replace-project conn
     {:key "CSE"
-     :cost-unit {:type "numeric"
+     :cost-unit {:type "points"
                  :format {:singular "point" :plural "points"}}}
     [{:key "CSE-1" :cost 10 :work-types ["Bug" "Documentation"]}
      {:key "CSE-2" :cost 25 :work-types ["Feature" "Documentation"]}
@@ -235,7 +235,7 @@ Getting the project back:
 > (get-project conn "CSE")
 ;=>
 {:key "CSE",
- :cost-unit {:type "numeric", :singular "point", :plural "points"},
+ :cost-unit {:type "points", :singular "point", :plural "points"},
  :issues ({:cost 10, :key "CSE-1", :work-types #{"Documentation" "Bug"}}
           {:cost 25, :key "CSE-2", :work-types #{"Documentation" "Feature"}}
           {:cost 5, :key "CSE-3", :work-types #{"Bug"}})}

--- a/codescene-jira-example.yml
+++ b/codescene-jira-example.yml
@@ -1,6 +1,5 @@
 sync:
-  # sync every 4 hours
-  hour-interval: 4
+  hour-interval: 4 # sync every 4 hours
 auth:
   service:
     username: johndoe
@@ -10,24 +9,26 @@ auth:
     username: jirauser
     password: jirapwd
 projects:
-- key: CSE2
-  cost-field: timeoriginalestimate
-  cost-unit:
-    type: numeric
-    format:
-      singular: '%d point'
-      plural: '%d points'
-  supported-work-types:
-    - Bug
-    - Feature
-    - Refactoring
-    - Documentation
-  ticket-id-pattern: CSE2-(\d+)
-- key: PROJ
-  cost-field: somecustomfield
-  cost-unit:
-    type: minutes
-  supported-work-types:
-    - Bug
-    - Documentation
-  ticket-id-pattern: PROJ-(\d+)
+  - key: CSE
+    cost-unit:
+      type: minutes
+    cost-field: timeoriginalestimate
+    supported-work-types:
+      - Bug
+      - Feature
+      - Refactoring
+      - Documentation
+    ticket-id-pattern: (CSE-\d+)
+  - key: DVP
+    cost-unit:
+      type: points
+        format:
+          singular: '%d point'
+          plural: '%d points'
+    cost-field: customfield_10006
+    supported-work-types:
+      - Bug
+      - Feature
+      - Refactoring
+      - Documentation
+    ticket-id-pattern: (DVP-\d+)

--- a/codescene-jira-example.yml
+++ b/codescene-jira-example.yml
@@ -22,9 +22,9 @@ projects:
   - key: DVP
     cost-unit:
       type: points
-        format:
-          singular: '%d point'
-          plural: '%d points'
+      format:
+        singular: '%d point'
+        plural: '%d points'
     cost-field: customfield_10006
     supported-work-types:
       - Bug


### PR DESCRIPTION
* Align the codescene-jira-example.yml with the example in README file
* Fix example configuration: use "points" instead of unsupported "numeric" cost unit and indent "format" key properly
* Small improvements of section "Running from the Command Line during development" in README
* remove "-X GET" from curl examples